### PR TITLE
Allow bbolt store to be created with *bbolt.Db

### DIFF
--- a/bbolt/bbolt.go
+++ b/bbolt/bbolt.go
@@ -64,6 +64,7 @@ func createBBoltStore(filePath string, options *bbolt.Options, cfg stoabs.Config
 	return WrapBBolt(db, cfg), nil
 }
 
+// WrapBBolt creates a KVStore using an existing bbolt.DB
 func WrapBBolt(db *bbolt.DB, cfg stoabs.Config) stoabs.KVStore {
 	var log *logrus.Logger
 	if cfg.Log != nil {

--- a/bbolt/bbolt.go
+++ b/bbolt/bbolt.go
@@ -61,11 +61,11 @@ func createBBoltStore(filePath string, options *bbolt.Options, cfg stoabs.Config
 		return nil, err
 	}
 
-	return WrapBBolt(db, cfg), nil
+	return Wrap(db, cfg), nil
 }
 
-// WrapBBolt creates a KVStore using an existing bbolt.DB
-func WrapBBolt(db *bbolt.DB, cfg stoabs.Config) stoabs.KVStore {
+// Wrap creates a KVStore using an existing bbolt.DB
+func Wrap(db *bbolt.DB, cfg stoabs.Config) stoabs.KVStore {
 	var log *logrus.Logger
 	if cfg.Log != nil {
 		log = cfg.Log

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/nuts-foundation/go-stoabs
 go 1.18
 
 require (
+	github.com/golang/mock v1.6.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.1
 	go.etcd.io/bbolt v1.3.6
@@ -10,7 +11,6 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/golang/mock v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,7 +25,6 @@ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d h1:L/IKR6COd7ubZrs2oTnTi73IhgqJ71c9s80WsQnh0Es=
 golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
In leia I need to wrap the current DB or use a given KVStore. If bbolt.Store is not accessible I need to create another wrapper....