### PR TITLE
Provide unwrap function fo retrieving underlying TX

### DIFF
--- a/bbolt/bbolt.go
+++ b/bbolt/bbolt.go
@@ -181,6 +181,10 @@ type bboltTx struct {
 	tx    *bbolt.Tx
 }
 
+func (b bboltTx) Unwrap() interface{} {
+	return b.tx
+}
+
 func (b bboltTx) GetShelfReader(shelfName string) (stoabs.Reader, error) {
 	return b.getBucket(shelfName)
 }

--- a/bbolt/bbolt_test.go
+++ b/bbolt/bbolt_test.go
@@ -21,6 +21,7 @@ package bbolt
 import (
 	"context"
 	"errors"
+	"go.etcd.io/bbolt"
 	"path"
 	"testing"
 
@@ -146,6 +147,18 @@ func TestBBolt_Read(t *testing.T) {
 		})
 		assert.NoError(t, err)
 	})
+}
+
+func TestBBolt_Unwrap(t *testing.T) {
+	store, _ := createStore(t)
+
+	var tx interface{}
+	_ = store.Read(func(innerTx stoabs.ReadTx) error {
+		tx = innerTx.Unwrap()
+		return nil
+	})
+	_, ok := tx.(*bbolt.Tx)
+	assert.True(t, ok)
 }
 
 func TestBBolt_WriteShelf(t *testing.T) {

--- a/store.go
+++ b/store.go
@@ -157,4 +157,6 @@ type ReadTx interface {
 	GetShelfReader(shelfName string) (Reader, error)
 	// Store returns the KVStore on which the transaction is started
 	Store() KVStore
+	// Unwrap returns the underlying, database specific transaction object. If not supported, it returns nil.
+	Unwrap() interface{}
 }


### PR DESCRIPTION
So implementing applications can use database-specific features (required for backup functionality in Nuts Node).