### PR TITLE
Log warning if bbolt.Open hangs on filelock

### DIFF
--- a/bbolt/bbolt_test.go
+++ b/bbolt/bbolt_test.go
@@ -21,13 +21,18 @@ package bbolt
 import (
 	"context"
 	"errors"
-	"go.etcd.io/bbolt"
+	"fmt"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"path"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/nuts-foundation/go-stoabs"
 	"github.com/nuts-foundation/go-stoabs/util"
 	"github.com/stretchr/testify/assert"
+	"go.etcd.io/bbolt"
 )
 
 var key = []byte{1, 2, 3}
@@ -390,4 +395,38 @@ func createStore(t *testing.T) (stoabs.KVStore, error) {
 		store.Close(context.Background())
 	})
 	return store, err
+}
+
+func TestBBolt_CreateBBoltStore(t *testing.T) {
+	t.Run("opening locked file logs warning", func(t *testing.T) {
+		fileTimeout = 10 * time.Millisecond
+		defer func() {
+			fileTimeout = defaultFileTimeout
+		}()
+		filename := filepath.Join(util.TestDirectory(t), "test-store")
+		logger, hook := test.NewNullLogger()
+
+		// create first store
+		store1, err := CreateBBoltStore(filename)
+		if !assert.NoError(t, err) {
+			return
+		}
+		defer store1.Close(context.Background())
+
+		// create second store
+		go func() {
+			store2, _ := CreateBBoltStore(filename, stoabs.WithLogger(logger))
+			_ = store2.Close(context.Background())
+		}()
+
+		// wait for logger
+		var lastEntry *logrus.Entry
+		util.WaitFor(t, func() (bool, error) {
+			lastEntry = hook.LastEntry()
+			return lastEntry != nil, nil
+		}, 100*fileTimeout, "time-out while waiting for log message")
+
+		assert.Equal(t, fmt.Sprintf("trying to open %s, but file appears to be locked", filename), lastEntry.Message)
+		assert.Equal(t, logrus.WarnLevel, lastEntry.Level)
+	})
 }

--- a/bbolt/bbolt_test.go
+++ b/bbolt/bbolt_test.go
@@ -415,7 +415,7 @@ func TestBBolt_CreateBBoltStore(t *testing.T) {
 
 		// create second store
 		go func() {
-			store2, _ := CreateBBoltStore(filename, stoabs.WithLogger(logger))
+			store2, _ := CreateBBoltStore(filename, stoabs.WithLogger(logger)) // hangs while store1 is open
 			_ = store2.Close(context.Background())
 		}()
 
@@ -426,7 +426,7 @@ func TestBBolt_CreateBBoltStore(t *testing.T) {
 			return lastEntry != nil, nil
 		}, 100*fileTimeout, "time-out while waiting for log message")
 
-		assert.Equal(t, fmt.Sprintf("trying to open %s, but file appears to be locked", filename), lastEntry.Message)
+		assert.Equal(t, fmt.Sprintf("Trying to open %s, but file appears to be locked", filename), lastEntry.Message)
 		assert.Equal(t, logrus.WarnLevel, lastEntry.Level)
 	})
 }

--- a/store.go
+++ b/store.go
@@ -60,6 +60,11 @@ func WithLogger(log *logrus.Logger) Option {
 	}
 }
 
+// DefaultLogger is the logger that will be used when none is provided to a store
+func DefaultLogger() *logrus.Logger {
+	return logrus.StandardLogger()
+}
+
 // ShelfStats contains statistics about a shelf.
 type ShelfStats struct {
 	// NumEntries holds the number of entries in the shelf.

--- a/util/test.go
+++ b/util/test.go
@@ -20,10 +20,14 @@ package util
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"regexp"
+	"runtime"
+	"sync"
 	"testing"
+	"time"
 )
 
 var invalidPathCharRegex = regexp.MustCompile("([^a-zA-Z0-9])")
@@ -46,4 +50,36 @@ func TestDirectory(t *testing.T) string {
 
 func normalizeTestName(t *testing.T) string {
 	return invalidPathCharRegex.ReplaceAllString(t.Name(), "_")
+}
+
+type Predicate func() (bool, error)
+
+func WaitFor(t *testing.T, p Predicate, timeout time.Duration, message string, msgArgs ...interface{}) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		b, err := p()
+		if !assert.NoError(t, err) {
+			return false
+		}
+		if b {
+			return true
+		}
+		if time.Now().After(deadline) {
+			assert.Fail(t, fmt.Sprintf(message, msgArgs...))
+			return false
+		}
+
+		// when running on CI there are some problems with testing go procedures. Probably during the low number of CPUs on those machines (1/4).
+		// This causes all go procedures to run on the same context.
+		// The logic below would block and allow other procedures to run and thus hopefully let other procedures run as well...
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			wg.Done()
+			runtime.Gosched()
+		}()
+		runtime.Gosched()
+		wg.Wait()
+	}
 }


### PR DESCRIPTION
Trying to open a file in bbolt that is locked currently makes `bbolt.Open` hang until it acquires the lock. This can make `CreateBBoltStore` hang forever without any indication of what is going wrong. 

This issue is most prominent during rolling updates where the old container only shuts down when the new container is online, but the new container cannot come online until the old container releases the lock on the db.