### PR TITLE
add NilReader to avoid error checking on ReadShelves

### DIFF
--- a/bbolt/bbolt.go
+++ b/bbolt/bbolt.go
@@ -147,13 +147,7 @@ func (b *store) WriteShelf(shelfName string, fn func(writer stoabs.Writer) error
 
 func (b *store) ReadShelf(shelfName string, fn func(reader stoabs.Reader) error) error {
 	return b.doTX(func(tx *bbolt.Tx) error {
-		shelf, err := bboltTx{tx: tx, store: b}.GetShelfReader(shelfName)
-		if err != nil {
-			return err
-		}
-		if shelf == nil {
-			return nil
-		}
+		shelf := bboltTx{tx: tx, store: b}.GetShelfReader(shelfName)
 		return fn(shelf)
 	}, false, nil)
 }
@@ -209,7 +203,7 @@ func (b bboltTx) Unwrap() interface{} {
 	return b.tx
 }
 
-func (b bboltTx) GetShelfReader(shelfName string) (stoabs.Reader, error) {
+func (b bboltTx) GetShelfReader(shelfName string) stoabs.Reader {
 	return b.getBucket(shelfName)
 }
 
@@ -221,12 +215,12 @@ func (b bboltTx) GetShelfWriter(shelfName string) (stoabs.Writer, error) {
 	return &bboltShelf{bucket: bucket}, nil
 }
 
-func (b bboltTx) getBucket(shelfName string) (stoabs.Reader, error) {
+func (b bboltTx) getBucket(shelfName string) stoabs.Reader {
 	bucket := b.tx.Bucket([]byte(shelfName))
 	if bucket == nil {
-		return nil, nil
+		return stoabs.NilReader{}
 	}
-	return &bboltShelf{bucket: bucket}, nil
+	return &bboltShelf{bucket: bucket}
 }
 
 func (b bboltTx) Store() stoabs.KVStore {

--- a/bbolt/bbolt_test.go
+++ b/bbolt/bbolt_test.go
@@ -140,11 +140,12 @@ func TestBBolt_Read(t *testing.T) {
 		store, _ := createStore(t)
 
 		err := store.Read(func(tx stoabs.ReadTx) error {
-			bucket, err := tx.GetShelfReader(shelf)
+			bucket := tx.GetShelfReader(shelf)
+			value, err := bucket.Get(stoabs.BytesKey("key"))
 			if err != nil {
 				return err
 			}
-			if bucket == nil {
+			if value == nil {
 				return nil
 			}
 			t.Fatal()
@@ -226,7 +227,7 @@ func TestBBolt_ReadShelf(t *testing.T) {
 		})
 
 		assert.NoError(t, err)
-		assert.False(t, called)
+		assert.True(t, called)
 	})
 }
 

--- a/store.go
+++ b/store.go
@@ -158,10 +158,32 @@ type WriteTx interface {
 
 // ReadTx is used to read from a KVStore.
 type ReadTx interface {
-	// GetShelfReader returns the specified shelf for reading. If it doesn't exist, nil is returned.
-	GetShelfReader(shelfName string) (Reader, error)
+	// GetShelfReader returns the specified shelf for reading. If it doesn't exist, a NilReader is returned that will return nil for all read operations.
+	GetShelfReader(shelfName string) Reader
 	// Store returns the KVStore on which the transaction is started
 	Store() KVStore
 	// Unwrap returns the underlying, database specific transaction object. If not supported, it returns nil.
 	Unwrap() interface{}
+}
+
+// NilReader is a shelfReader that always returns nil. It can be used when shelves do not exist.
+type NilReader struct{}
+
+func (n NilReader) Get(_ Key) ([]byte, error) {
+	return nil, nil
+}
+
+func (n NilReader) Iterate(_ CallerFn) error {
+	return nil
+}
+
+func (n NilReader) Range(_ Key, to Key, _ CallerFn) error {
+	return nil
+}
+
+func (n NilReader) Stats() ShelfStats {
+	return ShelfStats{
+		NumEntries: 0,
+		ShelfSize:  0,
+	}
 }


### PR DESCRIPTION
Lots of operations create a reader. The result is a reader and an error. This can be simplified by returning a NilReader which returns nil on every operation. This way the error check and not nil check can be removed for every reader creation.