### PR TITLE
Redis: retry ping to cope with starting Docker services

### DIFF
--- a/kvtests/common_tests.go
+++ b/kvtests/common_tests.go
@@ -648,7 +648,8 @@ func TestTransactionWriteLock(t *testing.T, storeProvider StoreProvider) {
 				t.SkipNow()
 			}
 
-			ctx, _ := context.WithTimeout(ctx, 500*time.Millisecond)
+			ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+			defer cancel()
 
 			err := store.Write(ctx, func(tx stoabs.WriteTx) error {
 				time.Sleep(time.Second)

--- a/redis7/redis_test.go
+++ b/redis7/redis_test.go
@@ -90,8 +90,14 @@ func TestRedis(t *testing.T) {
 
 func TestCreateRedisStore(t *testing.T) {
 	t.Run("unable to connect", func(t *testing.T) {
+		pingAttemptBackoff = 100 * time.Millisecond // speed up test
+		startTime := time.Now()
+
 		actual, err := CreateRedisStore("", &redis.Options{Addr: "localhost:9889"})
 		assert.ErrorContains(t, err, "unable to connect to Redis database")
 		assert.Nil(t, actual)
+
+		// Assert time took at least pingAttempts * pingAttemptBackoff
+		assert.GreaterOrEqual(t, time.Now().Sub(startTime), pingAttempts*pingAttemptBackoff)
 	})
 }


### PR DESCRIPTION
When running in Docker or other orchestrated environments, the Redis server might not be started yet when applications try to connect. We should retry the ping a few times.