### PR TITLE
Improve BBolt locking

### DIFF
--- a/bbolt/bbolt.go
+++ b/bbolt/bbolt.go
@@ -63,7 +63,6 @@ func createBBoltStore(filePath string, options *bbolt.Options, cfg stoabs.Config
 		return nil, err
 	}
 
-	// log warning if file opening hangs
 	done := make(chan bool, 1)
 	ticker := time.NewTicker(fileTimeout)
 	go func() {

--- a/kvtests/common_tests.go
+++ b/kvtests/common_tests.go
@@ -596,10 +596,6 @@ func TestWriteTransactions(t *testing.T, storeProvider StoreProvider) {
 
 func TestTransactionWriteLock(t *testing.T, storeProvider StoreProvider) {
 	ctx := context.Background()
-	supportsLockExpiry := func(store stoabs.KVStore) bool {
-		return true
-		//return fmt.Sprintf("%T", store) != "*bbolt.store"
-	}
 
 	t.Run("Transaction-Level Write Lock", func(t *testing.T) {
 		t.Run("Multiple routines try to lock", func(t *testing.T) {
@@ -644,9 +640,6 @@ func TestTransactionWriteLock(t *testing.T, storeProvider StoreProvider) {
 
 		t.Run("context expired", func(t *testing.T) {
 			store := createStore(t, storeProvider)
-			if !supportsLockExpiry(store) {
-				t.SkipNow()
-			}
 
 			ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 			defer cancel()

--- a/kvtests/common_tests.go
+++ b/kvtests/common_tests.go
@@ -21,7 +21,6 @@ package kvtests
 import (
 	"context"
 	"errors"
-	"fmt"
 	"github.com/nuts-foundation/go-stoabs"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -598,7 +597,8 @@ func TestWriteTransactions(t *testing.T, storeProvider StoreProvider) {
 func TestTransactionWriteLock(t *testing.T, storeProvider StoreProvider) {
 	ctx := context.Background()
 	supportsLockExpiry := func(store stoabs.KVStore) bool {
-		return fmt.Sprintf("%T", store) != "*bbolt.store"
+		return true
+		//return fmt.Sprintf("%T", store) != "*bbolt.store"
 	}
 
 	t.Run("Transaction-Level Write Lock", func(t *testing.T) {

--- a/store.go
+++ b/store.go
@@ -58,12 +58,14 @@ type KVStore interface {
 
 type Option func(config *Config)
 
+// Config specifies the configuration for a KVStore.
 type Config struct {
 	Log                *logrus.Logger
 	NoSync             bool
 	LockAcquireTimeout time.Duration
 }
 
+// DefaultConfig returns the default configuration.
 func DefaultConfig() Config {
 	return Config{
 		Log:                logrus.StandardLogger(),
@@ -71,18 +73,22 @@ func DefaultConfig() Config {
 	}
 }
 
+// WithLockAcquireTimeout overrides the default timeout for acquiring a lock.
 func WithLockAcquireTimeout(value time.Duration) Option {
 	return func(config *Config) {
 		config.LockAcquireTimeout = value
 	}
 }
 
+// WithNoSync specifies that the database should not flush its data to disk.
+// Support depends on the underlying database.
 func WithNoSync() Option {
 	return func(config *Config) {
 		config.NoSync = true
 	}
 }
 
+// WithLogger overrides the default logger.
 func WithLogger(log *logrus.Logger) Option {
 	return func(config *Config) {
 		config.Log = log
@@ -156,10 +162,12 @@ func WithWriteLock() TxOption {
 	return WriteLockOption{}
 }
 
+// AfterCommitOption is an option that invokes a function after a transaction is committed.
 type AfterCommitOption struct {
 	fn func()
 }
 
+// Invoke calls all functions registered with the AfterCommitOption.
 func (o AfterCommitOption) Invoke(opts []TxOption) {
 	for _, opt := range opts {
 		if ar, ok := opt.(*AfterCommitOption); ok {
@@ -174,10 +182,12 @@ func AfterCommit(fn func()) TxOption {
 	return &AfterCommitOption{fn: fn}
 }
 
+// OnRollbackOption is an option that invokes a function after a transaction is rolled back.
 type OnRollbackOption struct {
 	fn func()
 }
 
+// Invoke calls all functions registered with the OnRollbackOption.
 func (o OnRollbackOption) Invoke(opts []TxOption) {
 	for _, opt := range opts {
 		if ar, ok := opt.(*OnRollbackOption); ok {

--- a/store.go
+++ b/store.go
@@ -143,6 +143,7 @@ type Store interface {
 // TxOption holds options for store transactions.
 type TxOption interface{}
 
+// WriteLockOption see WithWriteLock
 type WriteLockOption struct {
 }
 
@@ -162,7 +163,7 @@ func WithWriteLock() TxOption {
 	return WriteLockOption{}
 }
 
-// AfterCommitOption is an option that invokes a function after a transaction is committed.
+// AfterCommitOption see AfterCommit
 type AfterCommitOption struct {
 	fn func()
 }
@@ -182,7 +183,7 @@ func AfterCommit(fn func()) TxOption {
 	return &AfterCommitOption{fn: fn}
 }
 
-// OnRollbackOption is an option that invokes a function after a transaction is rolled back.
+// OnRollbackOption see OnRollback
 type OnRollbackOption struct {
 	fn func()
 }

--- a/store_test.go
+++ b/store_test.go
@@ -21,9 +21,22 @@ package stoabs
 import (
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"time"
 )
 
-func TestTxOptions_RequestsWriteLock(t *testing.T) {
-	assert.True(t, TxOptions([]TxOption{WithWriteLock()}).RequestsWriteLock())
-	assert.False(t, TxOptions{}.RequestsWriteLock())
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	assert.NotEmpty(t, cfg.LockAcquireTimeout)
+	assert.NotNil(t, cfg.Log)
+}
+
+func TestAcquireLockTimeout(t *testing.T) {
+	cfg := DefaultConfig()
+	WithLockAcquireTimeout(time.Hour)(&cfg)
+	assert.Equal(t, time.Hour, cfg.LockAcquireTimeout)
+}
+
+func TestWriteLockOption(t *testing.T) {
+	assert.True(t, WriteLockOption{}.Enabled([]TxOption{WithWriteLock()}))
+	assert.False(t, WriteLockOption{}.Enabled([]TxOption{}))
 }

--- a/util/mutex.go
+++ b/util/mutex.go
@@ -1,0 +1,101 @@
+package util
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+)
+
+// RWLocker defines the interface for a read-write lock like sync.RWMutex
+type RWLocker interface {
+	sync.Locker
+	RLock()
+	TryRLock() bool
+	RUnlock()
+	TryLock() bool
+	RLocker() sync.Locker
+}
+
+var _ RWLocker = &sync.RWMutex{}
+
+// ContextRWLocker returns a RWMutex that supports context cancellation.
+type ContextRWLocker struct {
+	mux sync.RWMutex
+}
+
+// LockContext locks the RWLocker with the given context.
+// If the context is canceled the function will return immediately with the error from the context.
+// It will still acquire the lock on the background, but it will be released immediately.
+func (c *ContextRWLocker) LockContext(ctx context.Context) error {
+	return lockWithCancel(ctx, c.mux.Lock, c.mux.Unlock)
+}
+
+// RLockContext locks the RWLocker with the given context.
+// If the context is canceled the function will return immediately with the error from the context.
+// It will still acquire the lock on the background, but it will be released immediately.
+func (c *ContextRWLocker) RLockContext(ctx context.Context) error {
+	return lockWithCancel(ctx, c.mux.RLock, c.mux.RUnlock)
+}
+
+func lockWithCancel(ctx context.Context, fnLock func(), fnUnlock func()) error {
+	locked := make(chan bool)
+	expired := &atomic.Value{}
+
+	// We need an additional mutex to synchronize signalling the locking goroutine the context expired.
+	// Otherwise, if the context cancellation handler and locking goroutine execute concurrently,
+	// the context cancellation handler might return an error (which should cause an immediate unlock after acquiring the lock),
+	// which (the signal) might be lost when the locking goroutine is already finished (or just finishing).
+	m := &sync.Mutex{}
+
+	go func() {
+		fnLock()
+		m.Lock()
+		if expired.Load() != nil {
+			// Context expired, unlock immediately.
+			fnUnlock()
+		} else {
+			locked <- true
+		}
+		m.Unlock()
+	}()
+
+	select {
+	case <-ctx.Done():
+		m.Lock()
+		defer m.Unlock()
+		// context expired, signal to the locking goroutine to unlock immediately after acquiring the lock
+		expired.Store(true)
+		return ctx.Err()
+	case <-locked:
+		// we got the lock before the context expired
+		return nil
+	}
+}
+
+func (c *ContextRWLocker) Lock() {
+	c.mux.Lock()
+}
+
+func (c *ContextRWLocker) RLock() {
+	c.mux.RLock()
+}
+
+func (c *ContextRWLocker) TryLock() bool {
+	return c.mux.TryLock()
+}
+
+func (c *ContextRWLocker) RLocker() sync.Locker {
+	return c.mux.RLocker()
+}
+
+func (c *ContextRWLocker) TryRLock() bool {
+	return c.mux.TryRLock()
+}
+
+func (c *ContextRWLocker) Unlock() {
+	c.mux.Unlock()
+}
+
+func (c *ContextRWLocker) RUnlock() {
+	c.mux.RUnlock()
+}

--- a/util/mutex.go
+++ b/util/mutex.go
@@ -72,30 +72,37 @@ func lockWithCancel(ctx context.Context, fnLock func(), fnUnlock func()) error {
 	}
 }
 
+// Lock simply calls the underlying lock.
 func (c *ContextRWLocker) Lock() {
 	c.mux.Lock()
 }
 
+// RLock simply calls the underlying lock.
 func (c *ContextRWLocker) RLock() {
 	c.mux.RLock()
 }
 
+// TryLock simply calls the underlying lock.
 func (c *ContextRWLocker) TryLock() bool {
 	return c.mux.TryLock()
 }
 
+// RLocker simply calls the underlying lock.
 func (c *ContextRWLocker) RLocker() sync.Locker {
 	return c.mux.RLocker()
 }
 
+// TryRLock simply calls the underlying lock.
 func (c *ContextRWLocker) TryRLock() bool {
 	return c.mux.TryRLock()
 }
 
+// Unlock simply calls the underlying lock.
 func (c *ContextRWLocker) Unlock() {
 	c.mux.Unlock()
 }
 
+// RUnlock simply calls the underlying lock.
 func (c *ContextRWLocker) RUnlock() {
 	c.mux.RUnlock()
 }

--- a/util/mutex.go
+++ b/util/mutex.go
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2022 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package util
 
 import (
@@ -50,13 +68,13 @@ func lockWithCancel(ctx context.Context, fnLock func(), fnUnlock func()) error {
 	go func() {
 		fnLock()
 		m.Lock()
+		defer m.Unlock()
 		if expired.Load() != nil {
 			// Context expired, unlock immediately.
 			fnUnlock()
 		} else {
 			locked <- true
 		}
-		m.Unlock()
 	}()
 
 	select {

--- a/util/mutex_test.go
+++ b/util/mutex_test.go
@@ -1,0 +1,59 @@
+package util
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_ContextRWLocker(t *testing.T) {
+	t.Run("lock, unlock, then lock again", func(t *testing.T) {
+		l := ContextRWLocker{}
+		err := l.LockContext(context.Background())
+		l.Unlock()
+		assert.NoError(t, err)
+
+		err = l.LockContext(context.Background())
+		assert.NoError(t, err)
+	})
+	t.Run("rlock, unlock, then lock again", func(t *testing.T) {
+		l := ContextRWLocker{}
+		err := l.RLockContext(context.Background())
+		l.RUnlock()
+		assert.NoError(t, err)
+
+		err = l.RLockContext(context.Background())
+		assert.NoError(t, err)
+	})
+	t.Run("wlock, rlock", func(t *testing.T) {
+		l := &ContextRWLocker{}
+
+		err := l.LockContext(context.Background())
+		assert.NoError(t, err)
+		l.Unlock()
+
+		err = l.RLockContext(context.Background())
+		assert.NoError(t, err)
+		l.RUnlock()
+
+		err = l.LockContext(context.Background())
+		assert.NoError(t, err)
+		l.Unlock()
+	})
+	t.Run("rlock, rlock, unlock", func(t *testing.T) {
+		l := &ContextRWLocker{}
+
+		err := l.RLockContext(context.Background())
+		assert.NoError(t, err)
+
+		err = l.RLockContext(context.Background())
+		assert.NoError(t, err)
+
+		l.RUnlock()
+		l.RUnlock()
+
+		err = l.LockContext(context.Background())
+		assert.NoError(t, err)
+		l.Unlock()
+	})
+}

--- a/util/mutex_test.go
+++ b/util/mutex_test.go
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2022 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package util
 
 import (
@@ -55,5 +73,13 @@ func Test_ContextRWLocker(t *testing.T) {
 		err = l.LockContext(context.Background())
 		assert.NoError(t, err)
 		l.Unlock()
+	})
+	t.Run("context cancelled", func(t *testing.T) {
+		l := ContextRWLocker{}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := l.LockContext(ctx)
+		assert.ErrorIs(t, err, context.Canceled)
 	})
 }


### PR DESCRIPTION
- Improved TX option invocation design
- Fixed TX lock unlocking for Redis; previously happened after AfterCommit/OnRollback invocations, now happens before (found when enabling BBolt lock expiry test)
- Introduced configurable lock acquisition time-out (default 3s)
- Introduced lock cancellation for BBolt