### PR TITLE
Add database error

### DIFF
--- a/util/mutex.go
+++ b/util/mutex.go
@@ -20,6 +20,7 @@ package util
 
 import (
 	"context"
+	"github.com/nuts-foundation/go-stoabs"
 	"sync"
 	"sync/atomic"
 )
@@ -83,7 +84,7 @@ func lockWithCancel(ctx context.Context, fnLock func(), fnUnlock func()) error {
 		defer m.Unlock()
 		// context expired, signal to the locking goroutine to unlock immediately after acquiring the lock
 		expired.Store(true)
-		return ctx.Err()
+		return stoabs.DatabaseError(ctx.Err())
 	case <-locked:
 		// we got the lock before the context expired
 		return nil

--- a/util/mutex_test.go
+++ b/util/mutex_test.go
@@ -20,8 +20,10 @@ package util
 
 import (
 	"context"
+	"github.com/nuts-foundation/go-stoabs"
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"time"
 )
 
 func Test_ContextRWLocker(t *testing.T) {
@@ -81,5 +83,15 @@ func Test_ContextRWLocker(t *testing.T) {
 
 		err := l.LockContext(ctx)
 		assert.ErrorIs(t, err, context.Canceled)
+		assert.ErrorIs(t, err, stoabs.ErrDatabase{})
+	})
+	t.Run("context timeout", func(t *testing.T) {
+		l := ContextRWLocker{}
+		ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+		defer cancel()
+
+		err := l.LockContext(ctx)
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.ErrorIs(t, err, stoabs.ErrDatabase{})
 	})
 }

--- a/util/util.go
+++ b/util/util.go
@@ -18,7 +18,10 @@
 
 package util
 
-import "context"
+import (
+	"context"
+	"github.com/nuts-foundation/go-stoabs"
+)
 
 // CallWithTimeout invokes the given function and waits until either it finishes or the given context finishes.
 // If the context finishes before the function finishes, the timeoutCallback function is invoked.
@@ -30,7 +33,7 @@ func CallWithTimeout(ctx context.Context, fn func() error, timeoutCallback func(
 	select {
 	case <-ctx.Done():
 		timeoutCallback()
-		return ctx.Err()
+		return stoabs.DatabaseError(ctx.Err())
 	case err := <-closeError:
 		// Function completed, maybe with error
 		return err

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,73 @@
+package util
+
+import (
+	"context"
+	"errors"
+	"github.com/nuts-foundation/go-stoabs"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func Test_CallWithTimeout(t *testing.T) {
+	testTimeout := 5 * time.Millisecond
+	t.Run("ok", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+		defer cancel()
+		var didSomething, timeoutFnCalled bool
+
+		err := CallWithTimeout(ctx, func() error {
+			didSomething = true
+			return nil
+		}, func() { timeoutFnCalled = true })
+
+		assert.NoError(t, err)
+		assert.True(t, didSomething)
+		assert.False(t, timeoutFnCalled)
+	})
+
+	t.Run("err", func(t *testing.T) {
+		t.Run("context.Canceled is ErrDatabase", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+			cancel()
+			var timeoutFnCalled bool
+
+			err := CallWithTimeout(ctx, func() error {
+				return nil
+			}, func() { timeoutFnCalled = true })
+
+			assert.ErrorIs(t, err, context.Canceled)
+			assert.ErrorIs(t, err, stoabs.ErrDatabase{})
+			assert.True(t, timeoutFnCalled)
+		})
+
+		t.Run("context.DeadlineExceeded is ErrDatabase", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+			defer cancel()
+			var timeoutFnCalled bool
+
+			err := CallWithTimeout(ctx, func() error {
+				time.Sleep(testTimeout)
+				return nil
+			}, func() { timeoutFnCalled = true })
+
+			assert.ErrorIs(t, err, context.DeadlineExceeded)
+			assert.ErrorIs(t, err, stoabs.ErrDatabase{})
+			assert.True(t, timeoutFnCalled)
+		})
+
+		t.Run("user defined is not an ErrDatabase", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+			defer cancel()
+			var timeoutFnCalled bool
+
+			err := CallWithTimeout(ctx, func() error {
+				return errors.New("custom error")
+			}, func() { timeoutFnCalled = true })
+
+			assert.EqualError(t, err, "custom error")
+			assert.NotErrorIs(t, err, stoabs.ErrDatabase{})
+			assert.False(t, timeoutFnCalled)
+		})
+	})
+}


### PR DESCRIPTION
All DB and context errors are wrapped in ErrDatabase to signal that they can be retried

Key errors and user errors (errors thrown by functions passed to stoabs methods) are not wrapped