### PR TITLE
Group dependabot updates into weekly PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,11 @@ updates:
     # checks /go.mod
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      go-modules:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Switch dependabot from daily, ungrouped updates to **weekly grouped** PRs.

- `gomod`: weekly, grouped (minor+patch).
- **Major** bumps stay outside the group as individual PRs, so cross-breaking-change updates that need judgment remain individually reviewable.
- Preserves soak time and anti-drift currency.

Assisted by AI